### PR TITLE
Remove peer dependency of React Native and support RN0.47.0

### DIFF
--- a/android/src/main/java/com/RNProximityWakeLock/RNReactNativeProximityWakeLockPackage.java
+++ b/android/src/main/java/com/RNProximityWakeLock/RNReactNativeProximityWakeLockPackage.java
@@ -17,11 +17,11 @@ public class RNReactNativeProximityWakeLockPackage implements ReactPackage {
     }
 
     // Deprecated RN 0.47
- +  // @Override
+    // @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {		
       return Collections.emptyList();		
     }
-    
+
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();

--- a/android/src/main/java/com/RNProximityWakeLock/RNReactNativeProximityWakeLockPackage.java
+++ b/android/src/main/java/com/RNProximityWakeLock/RNReactNativeProximityWakeLockPackage.java
@@ -16,6 +16,12 @@ public class RNReactNativeProximityWakeLockPackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RNReactNativeProximityWakeLockModule(reactContext));
     }
 
+    // Deprecated RN 0.47
+ +  // @Override
+    public List<Class<? extends JavaScriptModule>> createJSModules() {		
+      return Collections.emptyList();		
+    }
+    
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();

--- a/android/src/main/java/com/RNProximityWakeLock/RNReactNativeProximityWakeLockPackage.java
+++ b/android/src/main/java/com/RNProximityWakeLock/RNReactNativeProximityWakeLockPackage.java
@@ -17,11 +17,6 @@ public class RNReactNativeProximityWakeLockPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();
     }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,5 @@
     "react-native"
   ],
   "author": "",
-  "license": "",
-  "peerDependencies": {
-    "react-native": "^0.41.2 || ^0.43.3"
-  }
+  "license": ""
 }


### PR DESCRIPTION
I referred https://github.com/jsierles/react-native-audio/blob/master/package.json

You can merge it if there is nothing wrong.

**Before**
<img width="935" alt="screen shot 2017-08-05 at 11 47 26 pm" src="https://user-images.githubusercontent.com/1323963/28996309-aaf8ceba-7a38-11e7-8fdf-8b0bb60d1361.png">

**After**
<img width="910" alt="screen shot 2017-08-05 at 11 47 15 pm" src="https://user-images.githubusercontent.com/1323963/28996307-a5661bec-7a38-11e7-8155-dee52d9d7c31.png">
